### PR TITLE
Updated package.json to include `jsx-loader`.  Fixes examples

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -15,6 +15,7 @@
     "react": "^0.11.1",
     "monorouter-react": "^0.2.0",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/domcache/package.json
+++ b/examples/domcache/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/isomorphic/package.json
+++ b/examples/isomorphic/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/lazyloadviews/package.json
+++ b/examples/lazyloadviews/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/notfound/package.json
+++ b/examples/notfound/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/preloadermiddleware/package.json
+++ b/examples/preloadermiddleware/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/react-frozenhead/package.json
+++ b/examples/react-frozenhead/package.json
@@ -17,6 +17,7 @@
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
     "webpack": "^1.3.2-beta9",
-    "react-frozenhead": "^0.1.0"
+    "react-frozenhead": "^0.1.0",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/react-template/package.json
+++ b/examples/react-template/package.json
@@ -17,6 +17,7 @@
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
     "webpack": "^1.3.2-beta9",
-    "react-template": "^0.3.1"
+    "react-template": "^0.3.1",
+    "jsx-loader": "~0.11.0"
   }
 }

--- a/examples/renderinitial/package.json
+++ b/examples/renderinitial/package.json
@@ -16,6 +16,7 @@
     "monorouter-react": "^0.2.0",
     "connect-monorouter": "^0.2.1",
     "express": "^4.7.2",
-    "webpack": "^1.3.2-beta9"
+    "webpack": "^1.3.2-beta9",
+    "jsx-loader": "~0.11.0"
   }
 }


### PR DESCRIPTION
Due to `jsx-loader` not being included, the examples would not compile and run.  This fixes that.  
