### PR TITLE
Merge opts into Request

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,3 +1,4 @@
+var extend = require('xtend/mutable');
 var queryString = require('query-string');
 var urllite = require('urllite');
 var Cancel = require('./errors/Cancel');
@@ -38,7 +39,7 @@ function Request(url, opts) {
     }
   }
 
-  importOwnProps(this, opts);
+  extend(this, opts);
   this.location = parsed;
   this.url = getUrl(parsed, opts && opts.root);
   this.originalUrl = parsed.pathname + parsed.search;
@@ -92,13 +93,3 @@ Request.prototype.cancel = function() {
 Request.prototype.canceled = false;
 
 module.exports = Request;
-
-function importOwnProps(obj, src){
-  var own = {}.hasOwnProperty;
-  for (var key in src) {
-    if (own.call(src, key)) {
-      obj[key] = src[key];
-    }
-  }
-  return obj;
-}

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -38,6 +38,7 @@ function Request(url, opts) {
     }
   }
 
+  importOwnProps(this, opts);
   this.location = parsed;
   this.url = getUrl(parsed, opts && opts.root);
   this.originalUrl = parsed.pathname + parsed.search;
@@ -50,9 +51,6 @@ function Request(url, opts) {
   this.query = queryString.parse(parsed.search);
   this.hash = parsed.hash;
   this.fragment = parsed.hash.replace(/^#/, '');
-  this.initialOnly = opts && opts.initialOnly;
-  this.first = opts && opts.first;
-  this.cause = opts && opts.cause;
 }
 
 // Make requests event emitters.
@@ -94,3 +92,13 @@ Request.prototype.cancel = function() {
 Request.prototype.canceled = false;
 
 module.exports = Request;
+
+function importOwnProps(obj, src){
+  var own = {}.hasOwnProperty;
+  for (var key in src) {
+    if (own.call(src, key)) {
+      obj[key] = src[key];
+    }
+  }
+  return obj;
+}

--- a/lib/__tests__/Request-test.js
+++ b/lib/__tests__/Request-test.js
@@ -59,4 +59,16 @@ describe('Request', function() {
     expect(req.from(['somethingelse'])).toBe(false);
   });
 
+  it('should expose all the opts', function() {
+    var req = new Request('',
+      {
+        first: false,
+        initialOnly: true,
+        originalReq: {foo: true}
+      });
+    expect(req.first).toBe(false);
+    expect(req.initialOnly).toBe(true);
+    expect(req.originalReq.foo).toBe(true);
+  });
+
 });

--- a/standalone/monorouter.js
+++ b/standalone/monorouter.js
@@ -127,6 +127,7 @@ function Request(url, opts) {
     }
   }
 
+  importOwnProps(this, opts);
   this.location = parsed;
   this.url = getUrl(parsed, opts && opts.root);
   this.originalUrl = parsed.pathname + parsed.search;
@@ -139,9 +140,6 @@ function Request(url, opts) {
   this.query = queryString.parse(parsed.search);
   this.hash = parsed.hash;
   this.fragment = parsed.hash.replace(/^#/, '');
-  this.initialOnly = opts && opts.initialOnly;
-  this.first = opts && opts.first;
-  this.cause = opts && opts.cause;
 }
 
 // Make requests event emitters.
@@ -183,6 +181,16 @@ Request.prototype.cancel = function() {
 Request.prototype.canceled = false;
 
 module.exports = Request;
+
+function importOwnProps(obj, src){
+  var own = {}.hasOwnProperty;
+  for (var key in src) {
+    if (own.call(src, key)) {
+      obj[key] = src[key];
+    }
+  }
+  return obj;
+}
 
 },{"./errors/Cancel":7,"inherits":21,"query-string":22,"urllite":25,"urllite/lib/extensions/resolve":29,"wolfy87-eventemitter":31}],3:[function(_dereq_,module,exports){
 var inherits = _dereq_('inherits');

--- a/standalone/monorouter.js
+++ b/standalone/monorouter.js
@@ -127,7 +127,6 @@ function Request(url, opts) {
     }
   }
 
-  importOwnProps(this, opts);
   this.location = parsed;
   this.url = getUrl(parsed, opts && opts.root);
   this.originalUrl = parsed.pathname + parsed.search;
@@ -140,6 +139,9 @@ function Request(url, opts) {
   this.query = queryString.parse(parsed.search);
   this.hash = parsed.hash;
   this.fragment = parsed.hash.replace(/^#/, '');
+  this.initialOnly = opts && opts.initialOnly;
+  this.first = opts && opts.first;
+  this.cause = opts && opts.cause;
 }
 
 // Make requests event emitters.
@@ -181,16 +183,6 @@ Request.prototype.cancel = function() {
 Request.prototype.canceled = false;
 
 module.exports = Request;
-
-function importOwnProps(obj, src){
-  var own = {}.hasOwnProperty;
-  for (var key in src) {
-    if (own.call(src, key)) {
-      obj[key] = src[key];
-    }
-  }
-  return obj;
-}
 
 },{"./errors/Cancel":7,"inherits":21,"query-string":22,"urllite":25,"urllite/lib/extensions/resolve":29,"wolfy87-eventemitter":31}],3:[function(_dereq_,module,exports){
 var inherits = _dereq_('inherits');


### PR DESCRIPTION
We needed a way to augment the `Request` instance so that we can get access to the original Express request when rendering server-side. 

This PR merges all the "own properties" from `opts` onto the Request instance. This allows, for example, middleware (such as `connect-monorouter`) to attach a reference to the original request for use in the route.
